### PR TITLE
build: seperate SSL certs from the code base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 
 # production
 /build
-/docker/nginx/ssl
 
 # misc
 .DS_Store
@@ -36,12 +35,7 @@ yarn-error.log*
 .vercel
 
 # post build
-/public/tags/
 /public/*.xml
 /public/robots.txt
-
-# SSL
-/docker/ssl
-
 
 .idea

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,9 +25,9 @@ services:
     container_name: mk-nginx
     restart: unless-stopped
     volumes:
-      - ./ssl/cf/ecc.pem:/etc/nginx/ssl/ecc.pem:ro
-      - ./ssl/cf/priv.key:/etc/nginx/ssl/priv.key:ro
-      - ./ssl/dh/dhparam-2048.pem:/etc/nginx/ssl/dhparam-2048.pem:ro
+      - /etc/ssl/mkreg/cf/ecc.pem:/etc/nginx/ssl/ecc.pem:ro
+      - /etc/ssl/mkreg/cf/priv.key:/etc/nginx/ssl/priv.key:ro
+      - /etc/ssl/mkreg/dh/dhparam-2048.pem:/etc/nginx/ssl/dhparam-2048.pem:ro
       - /var/log/nginx:/var/log/nginx
     ports:
       - 80:80


### PR DESCRIPTION
- Move certificates from inside the docker folder to the proper location
on the host system, this was a stupid mistake from the start anyway —
SSL files should not be in the same directory as the code base.
- Remove SSL entries from .gitignore, also some other un-needed paths
- Adjust SSL location on docker nginx binded mount volumes