### PR TITLE
feat: NGINX use expires directive instead of cache control

### DIFF
--- a/docker/nginx/conf.d/nextjs.conf
+++ b/docker/nginx/conf.d/nextjs.conf
@@ -125,7 +125,7 @@ server {
         # default headers
         include /etc/nginx/headers.conf;
         include /etc/nginx/proxy.conf;
-        more_set_headers 'Cache-Control: max-age=3600';
+        expires 1h;
         more_set_headers 'Cloudflare-CDN-Cache-Control: max-age=7200';
         proxy_pass http://mk-next;
     }
@@ -146,7 +146,7 @@ server {
         access_log off;
         include /etc/nginx/headers.conf;
         include /etc/nginx/proxy.conf;
-        more_set_headers 'Cache-Control: max-age=300';
+        expires 180s;
         more_set_headers 'Cloudflare-CDN-Cache-Control: max-age=120';
         proxy_pass http://mk-next;
     }
@@ -158,7 +158,7 @@ server {
         add_header Access-Control-Allow-Origin '*';
         include /etc/nginx/headers.conf;
         include /etc/nginx/proxy.conf;
-        more_set_headers 'Cache-Control: max-age=259200';
+        expires 3d;
         more_set_headers 'Cloudflare-CDN-Cache-Control: max-age=604800';
         proxy_pass http://mk-next;
     }
@@ -169,7 +169,7 @@ server {
         add_header Access-Control-Allow-Origin '*';
         include /etc/nginx/headers.conf;
         include /etc/nginx/proxy.conf;
-        more_set_headers 'Cache-Control: max-age=259200';
+        expires 3d;
         more_set_headers 'Cloudflare-CDN-Cache-Control: max-age=604800';
         proxy_pass http://mk-next;
     }


### PR DESCRIPTION
Using expires instead of cache control works better with CF workers...